### PR TITLE
chore: bump package version to 0.0.0 in pyproject.toml and workspace

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pwi"
-version = "0.1.0"
+version = "0.0.0"
 description = "Modern, type-safe, zero-dependency python library for controlling Planewave devices"
 readme = "README.md"
 authors = [{ name = "michealroberts", email = "michael@observerly.com" }]


### PR DESCRIPTION
chore: bump package version to 0.0.0 in pyproject.toml and workspace